### PR TITLE
feat: add new snippets (JavaScript, TypeScript, HTML)

### DIFF
--- a/snippets/html.json
+++ b/snippets/html.json
@@ -1,0 +1,215 @@
+{
+    // HTML Doc writing
+    "HTML Doc: warning block": {
+        "prefix": "doc-warning-block",
+        "body": [
+            "div class=\"rule-box warning\">",
+            "    <i class=\"mdi mdi-comment-alert\"></i>",
+            "    $1",
+            "</div>"
+        ],
+		"description": "Add a warning block."
+    },
+    "HTML Doc: success block": {
+        "prefix": "doc-success-block",
+        "body": [
+            "div class=\"rule-box success\">",
+            "    <i class=\"mdi mdi-checkbox-marked-circle\"></i>",
+            "    $1",
+            "</div>"
+        ],
+		"description": "Add a success block."
+    },
+    "HTML Doc: note block": {
+        "prefix": "doc-note-block",
+        "body": [
+            "div class=\"rule-box note\">",
+            "    <i class=\"mdi mdi-note-text\"></i>",
+            "    $1",
+            "</div>"
+        ],
+		"description": "Add a note block."
+    },
+    "HTML Doc: information block": {
+        "prefix": "doc-info-block",
+        "body": [
+            "div class=\"rule-box info\">",
+            "    <i class=\"mdi mdi-information\"></i>",
+            "    $1",
+            "</div>"
+        ],
+		"description": "Add an information block."
+    },
+    "HTML Doc: information 'Link' block": {
+        "prefix": "doc-info-link-block",
+        "body": [
+            "div class=\"rule-box info\">",
+            "    <i class=\"mdi mdi-link-variant\"></i>",
+            "    $1",
+            "</div>"
+        ],
+		"description": "Add an information \"Link\" block."
+    },
+    "HTML Doc: information 'Why?' block": {
+        "prefix": "doc-info-why-block",
+        "body": [
+            "div class=\"rule-box info\">",
+            "    <i class=\"mdi mdi-help-circle\"></i>",
+            "    $1",
+            "</div>"
+        ],
+		"description": "Add an information \"Why?\" block."
+    },
+
+    "HTML Doc: inline code block": {
+        "prefix": "doc-inline-code-block",
+        "body": [
+            "span class=\"code\">$1</span>",
+        ],
+		"description": "Add an inline code block."
+    },
+
+    "HTML Doc: ESLint rule": {
+        "prefix": "doc-eslint-rule",
+        "body": [
+            "li>",
+            "    <a href=\"http://eslint.org/docs/rules/$1\" target=\"_blank\">$1</a>",
+            "    <br>",
+            "    $2",
+            "</div>"
+        ],
+		"description": "Add an ESLint rule."
+    },
+    "HTML Doc: ESLint warning only rule": {
+        "prefix": "doc-warning-only-eslint-rule",
+        "body": [
+            "li>",
+            "    <a href=\"http://eslint.org/docs/rules/$1\" target=\"_blank\">$1</a>",
+            "    <i class=\"mdi mdi-alert is-warning\" title=\"This rule only displays a warning\"></i>",
+            "    <br>",
+            "    $2",
+            "</div>"
+        ],
+		"description": "Add an ESLint warning only rule."
+    },
+    "HTML Doc: ESLint good practice rule": {
+        "prefix": "doc-good-practice-eslint-rule",
+        "body": [
+            "li>",
+            "    <a href=\"http://eslint.org/docs/rules/$1\" target=\"_blank\">$1</a>",
+            "    <i class=\"mdi mdi-alarm-off is-not-enforced\" title=\"This rule is not enforced, it's just a good practice.\"></i>",
+            "    <br>",
+            "    $2",
+            "</div>"
+        ],
+		"description": "Add an ESLint good practice (not enforced) rule."
+    },
+    "HTML Doc: ESLint ES6+ rule": {
+        "prefix": "doc-es6-eslint-rule",
+        "body": [
+            "li>",
+            "    <a href=\"http://eslint.org/docs/rules/$1\" target=\"_blank\">$1</a>",
+            "    <i class=\"mdi mdi-alarm-off is-not-enforced\" title=\"This rule is not enforced in ES5, but is in ES6+.\">(ES6+ only)</i>",
+            "    <br>",
+            "    $2",
+            "</div>"
+        ],
+		"description": "Add an ESLint ES6+ rule."
+    },
+
+    "HTML Doc: Unicorn plugin rule": {
+        "prefix": "doc-unicorn-rule",
+        "body": [
+            "li>",
+            "    <a href=\"https://github.com/sindresorhus/eslint-plugin-unicorn/blob/master/docs/rules/$1.md\" target=\"_blank\">$1</a>",
+            "    <br>",
+            "    $2",
+            "</div>"
+        ],
+		"description": "Add an Unicorn plugin rule."
+    },
+    "HTML Doc: Unicorn plugin warning only rule": {
+        "prefix": "doc-unicorn-rule",
+        "body": [
+            "li>",
+            "    <a href=\"https://github.com/sindresorhus/eslint-plugin-unicorn/blob/master/docs/rules/$1.md\" target=\"_blank\">$1</a>",
+            "    <i class=\"mdi mdi-alert is-warning\" title=\"This rule only displays a warning\"></i>",
+            "    <br>",
+            "    $2",
+            "</div>"
+        ],
+		"description": "Add an Unicorn plugin warning only rule."
+    },
+    "HTML Doc: Unicorn good practice rule": {
+        "prefix": "doc-good-practice-unicorn-rule",
+        "body": [
+            "li>",
+            "    <a href=\"https://github.com/sindresorhus/eslint-plugin-unicorn/blob/master/docs/rules/$1.md\" target=\"_blank\">$1</a>",
+            "    <i class=\"mdi mdi-alarm-off is-not-enforced\" title=\"This rule is not enforced, it's just a good practice.\"></i>",
+            "    <br>",
+            "    $2",
+            "</div>"
+        ],
+		"description": "Add an Unicorn good practice (not enforced) rule."
+    },
+    "HTML Doc: Unicorn ES6+ rule": {
+        "prefix": "doc-es6-unicorn-rule",
+        "body": [
+            "li>",
+            "    <a href=\"https://github.com/sindresorhus/eslint-plugin-unicorn/blob/master/docs/rules/$1.md\" target=\"_blank\">$1</a>",
+            "    <i class=\"mdi mdi-alarm-off is-not-enforced\" title=\"This rule is not enforced in ES5, but is in ES6+.\">(ES6+ only)</i>",
+            "    <br>",
+            "    $2",
+            "</div>"
+        ],
+		"description": "Add an Unicorn ES6+ rule."
+    },
+
+    "HTML Doc: AngularJS plugin rule": {
+        "prefix": "doc-angularjs-rule",
+        "body": [
+            "li>",
+            "    <a href=\"https://github.com/Gillespie59/eslint-plugin-angular/blob/master/docs/$1.md\" target=\"_blank\">$1</a>",
+            "    <br>",
+            "    $2",
+            "</div>"
+        ],
+		"description": "Add an AngularJS plugin rule."
+    },
+    "HTML Doc: AngularJS plugin warning only rule": {
+        "prefix": "doc-angularjs-rule",
+        "body": [
+            "li>",
+            "    <a href=\"https://github.com/Gillespie59/eslint-plugin-angular/blob/master/docs/$1.md\" target=\"_blank\">$1</a>",
+            "    <i class=\"mdi mdi-alert is-warning\" title=\"This rule only displays a warning\"></i>",
+            "    <br>",
+            "    $2",
+            "</div>"
+        ],
+		"description": "Add an AngularJS plugin warning only rule."
+    },
+    "HTML Doc: AngularJS good practice rule": {
+        "prefix": "doc-good-practice-angularjs-rule",
+        "body": [
+            "li>",
+            "    <a href=\"https://github.com/Gillespie59/eslint-plugin-angular/blob/master/docs/$1.md\" target=\"_blank\">$1</a>",
+            "    <i class=\"mdi mdi-alarm-off is-not-enforced\" title=\"This rule is not enforced, it's just a good practice.\"></i>",
+            "    <br>",
+            "    $2",
+            "</div>"
+        ],
+		"description": "Add an AngularJS good practice (not enforced) rule."
+    },
+    "HTML Doc: AngularJS ES6+ rule": {
+        "prefix": "doc-es6-angularjs-rule",
+        "body": [
+            "li>",
+            "    <a href=\"https://github.com/Gillespie59/eslint-plugin-angular/blob/master/docs/$1.md\" target=\"_blank\">$1</a>",
+            "    <i class=\"mdi mdi-alarm-off is-not-enforced\" title=\"This rule is not enforced in ES5, but is in ES6+.\">(ES6+ only)</i>",
+            "    <br>",
+            "    $2",
+            "</div>"
+        ],
+		"description": "Add an AngularJS ES6+ rule."
+    },
+}

--- a/snippets/javascript.json
+++ b/snippets/javascript.json
@@ -1,11 +1,130 @@
 {
-    // Angular
-    "@ngInject": {
+    // Misc
+
+    // AngularJS
+    "Simple watcher": {
+        "prefix": "ng-watch-variable",
+        "body": [
+            "\\$scope.\\$watch('${1:vm.}', (newValue, oldValue) => {",
+            "    if (newValue === oldValue) {",
+            "        return;",
+            "    }",
+            "",
+            "    console.log(newValue, oldValue);",
+            "}, true);"
+        ],
+		"description": "Add an AngularJS watcher on a view model variable."
+    },
+    "Function watcher": {
+        "prefix": "ng-watch-function",
+        "body": [
+            "\\$scope.\\$watch(() => {",
+            "    return $1;",
+            "}, (newValue, oldValue) => {",
+            "    if (newValue === oldValue) {",
+            "        return;",
+            "    }",
+            "",
+            "    console.log(newValue, oldValue);",
+            "}, true);"
+        ],
+		"description": "Add an AngularJS watcher on a function's return value."
+    },
+
+    "Simple event listener": {
+        "prefix": "ng-evt",
+        "body": [
+            "\\$scope.\\$on('$1', (${2:evt, { params \\}}) => {",
+            "    $3",
+            "});"
+        ],
+		"description": "Add an AngularJS event listener on the scope."
+    },
+    "Root event listener": {
+        "prefix": "ng-evt-root",
+        "body": [
+            "\\$rootScope.\\$on('$1', (${2:evt, { params \\}}) => {",
+            "    $3",
+            "});"
+        ],
+		"description": "Add an AngularJS event listener on the root scope."
+    },
+
+    "Send event downward": {
+        "prefix": "ng-broadcast",
+        "body": [
+            "\\$scope.\\$broadcast('$1'${2:, { params \\}});"
+        ],
+		"description": "Send an AngularJS event down to the current scope's children"
+    },
+    "Send root event downward": {
+        "prefix": "ng-broadcast-root",
+        "body": [
+            "\\$rootScope.\\$broadcast('$1'${2:, { params \\}});"
+        ],
+		"description": "Send an AngularJS event down from the application's root scope"
+    },
+    "Send event upward": {
+        "prefix": "ng-emit",
+        "body": [
+            "\\$scope.\\$emit('$1'${2:, { params \\}});"
+        ],
+		"description": "Send an AngularJS event up to the current scope's parents"
+    },
+
+    "Simple 'angular.isUndefinedOrEmpty'": {
+        "prefix": "ng-ue",
+        "body": [
+            "angular.isUndefinedOrEmpty($1)"
+        ],
+		"description": "Angular 'isUndefinedOrEmpty' helper."
+    },
+    "Advanced 'angular.isUndefinedOrEmpty'": {
+        "prefix": "ng-uea",
+        "body": [
+            "angular.isUndefinedOrEmpty([$1], '${2:some}')"
+        ],
+		"description": "Advanced Angular 'isUndefinedOrEmpty' helper."
+    },
+    "Simple 'angular.isDefinedAndFilled'": {
+        "prefix": "ng-df",
+        "body": [
+            "angular.isDefinedAndFilled($1)"
+        ],
+		"description": "Angular 'isDefinedAndFilled' helper."
+    },
+    "Advanced 'angular.isDefinedAndFilled'": {
+        "prefix": "ng-dfa",
+        "body": [
+            "angular.isDefinedAndFilled([$1], '${2:every}')"
+        ],
+		"description": "Advanced Angular 'isDefinedAndFilled' helper."
+    },
+
+    "Refactor into 'angular.forEach'": {
+        "prefix": "ng-afr",
+        "body": [
+            "angular.forEach($1, ($2${3:, index}) => {"
+        ],
+		"description": "Refactor a 'for' loop into an Angular's 'forEach' loop."
+    },
+    "Simple 'angular.forEach'": {
+        "prefix": "ng-af",
+        "body": [
+            "angular.forEach($1, ($2${3:, index}) => {",
+            "    $4",
+            "});"
+        ],
+		"description": "Generate a simple Angular's 'forEach' loop."
+    },
+
+    "ngInject": {
         "prefix": "ng-inject",
         "body": [
-            "/* @ngInject */"
+            "'ngInject';",
+            ""
         ],
-		"description": "Add an auto-injection loader comment."
+		"description": "Add an auto-injection loader directive at the top of a function."
     },
 
 	// ESLint
@@ -16,7 +135,6 @@
         ],
 		"description": "Disable ESLint (with optional rule name to disable) from now on."
     },
-
     "Disable ESLint - Next line": {
         "prefix": "eslint-disable-next",
         "body": [
@@ -24,7 +142,6 @@
         ],
 		"description": "Disable ESLint (with optional rule name to disable) for the next line only."
     },
-
     "Enable ESLint": {
         "prefix": "eslint-enable",
         "body": [
@@ -43,7 +160,84 @@
         ],
 		"description": "Add a default separator."
     },
-
+    "Separator for private attributes": {
+        "prefix": "separator-private-attributes",
+        "body": [
+            "",
+            "/////////////////////////////",
+            "//                         //",
+            "//    Private attributes   //",
+            "//                         //",
+            "/////////////////////////////",
+            ""
+        ],
+		"description": "Add a private attributes separator."
+    },
+    "Separator for public attributes": {
+        "prefix": "separator-public-attributes",
+        "body": [
+            "",
+            "/////////////////////////////",
+            "//                         //",
+            "//    Public attributes    //",
+            "//                         //",
+            "/////////////////////////////",
+            ""
+        ],
+		"description": "Add a public attributes separator."
+    },
+    "Separator for services and utilities": {
+        "prefix": "separator-services-utilities",
+        "body": [
+            "",
+            "/////////////////////////////",
+            "",
+            "/**",
+            " * Services and utilities.",
+            " */",
+            ""
+        ],
+		"description": "Add a services and utilities separator."
+    },
+    "Separator for private functions": {
+        "prefix": "separator-private-functions",
+        "body": [
+            "",
+            "/////////////////////////////",
+            "//                         //",
+            "//    Private functions    //",
+            "//                         //",
+            "/////////////////////////////",
+            ""
+        ],
+		"description": "Add a private functions separator."
+    },
+    "Separator for public functions": {
+        "prefix": "separator-public-functions",
+        "body": [
+            "",
+            "/////////////////////////////",
+            "//                         //",
+            "//     Public functions    //",
+            "//                         //",
+            "/////////////////////////////",
+            ""
+        ],
+		"description": "Add a public functions separator."
+    },
+    "Separator for watchers": {
+        "prefix": "separator-watchers",
+        "body": [
+            "",
+            "/////////////////////////////",
+            "//                         //",
+            "//        Watchers         //",
+            "//                         //",
+            "/////////////////////////////",
+            ""
+        ],
+		"description": "Add a watchers separator."
+    },
     "Separator for events": {
         "prefix": "separator-events",
         "body": [
@@ -57,7 +251,6 @@
         ],
 		"description": "Add an events separator."
     },
-
     "Separator for init method": {
         "prefix": "separator-init",
         "body": [
@@ -72,88 +265,110 @@
 		"description": "Add an init separator."
     },
 
-    "Separator for private attributes": {
-        "prefix": "separator-private-attributes",
+    "EOF export": {
+        "prefix": "export",
         "body": [
             "",
-            "/////////////////////////////",
-            "//                         //",
-            "//    Private attributes   //",
-            "//                         //",
-            "/////////////////////////////",
-            ""
+            "/////////////////////////////"
+            "",
+            "export { ${1:exportName} };"
         ],
-		"description": "Add a private attributes separator."
+		"description": "End of file export directive (with separator)."
     },
 
-    "Separator for public attributes": {
-        "prefix": "separator-public-attributes",
+    // JSDoc
+    "JSDoc: '@type {string}'": {
+        "prefix": "@ts",
         "body": [
-            "",
-            "/////////////////////////////",
-            "//                         //",
-            "//    Public attributes    //",
-            "//                         //",
-            "/////////////////////////////",
-            ""
+            "@type {string}"
         ],
-		"description": "Add a public attributes separator."
+		"description": "Add a '@type' tag for a string variable."
+    },
+    "JSDoc: '@type {Object}'": {
+        "prefix": "@to",
+        "body": [
+           "@type {Object}"
+        ],
+		"description": "Add a '@type' tag for an Object variable."
+    },
+    "JSDoc: '@type {number}'": {
+        "prefix": "@tn",
+        "body": [
+            "@type {number}"
+        ],
+		"description": "Add a '@type' tag for a number variable."
+    },
+    "JSDoc: '@type {Function}'": {
+        "prefix": "@tf",
+        "body": [
+            "@type {Function}"
+        ],
+		"description": "Add a '@type' tag for a Function variable."
+    },
+    "JSDoc: '@type {Date}'": {
+        "prefix": "@td",
+        "body": [
+            "@type {Date}"
+        ],
+		"description": "Add a '@type' tag for a Date variable."
+    },
+    "JSDoc: '@type {Array<?>}'": {
+        "prefix": "@ta",
+        "body": [
+            "@type {Array<${1:?}>}"
+        ],
+		"description": "Add a '@type' tag for an Array variable."
+    },
+    "JSDoc: '@type {Date}'": {
+        "prefix": "@td",
+        "body": [
+            "@type {Date}"
+        ],
+		"description": "Add a '@type' tag for a Date variable."
+    },
+    "JSDoc: '@type'": {
+        "prefix": "@type",
+        "body": [
+            "@type {${1:*}}"
+        ],
+		"description": "Add a generic '@type' tag."
     },
 
-    "Separator for private functions": {
-        "prefix": "separator-private-functions",
+    "JSDoc: '@constant'": {
+        "prefix": "@cst",
         "body": [
-            "",
-            "/////////////////////////////",
-            "//                         //",
-            "//    Private functions    //",
-            "//                         //",
-            "/////////////////////////////",
-            ""
+            "@constant"
         ],
-		"description": "Add a private functions separator."
+		"description": "Add a '@constant' tag."
+    },
+    "JSDoc: '@readonly'": {
+        "prefix": "@ro",
+        "body": [
+            "@readonly"
+        ],
+		"description": "Add a '@readonly' tag."
     },
 
-    "Separator for public functions": {
-        "prefix": "separator-public-functions",
+    "JSDoc: mandatory '@param'": {
+        "prefix": "@param",
         "body": [
-            "",
-            "/////////////////////////////",
-            "//                         //",
-            "//     Public functions    //",
-            "//                         //",
-            "/////////////////////////////",
-            ""
+            "@param {${1:*}} ${2:paramName} ${3:Description}."
         ],
-		"description": "Add a public functions separator."
+		"description": "Add a mandatory '@param' tag."
+    },
+    "JSDoc: optional '@param'": {
+        "prefix": "@param-opt",
+        "body": [
+            "@param {${1:*}} [${2:paramName}=${3:<default value>}] ${4:Description}."
+        ],
+		"description": "Add an optional '@param' tag."
     },
 
-    "Separator for services and utilities": {
-        "prefix": "separator-services-utilities",
+    "JSDoc: '@return'": {
+        "prefix": "@return",
         "body": [
-            "",
-            "/////////////////////////////",
-            "",
-            "/**",
-            " * Services and utilities.",
-            " */",
-            ""
+            "@return {${1:*}} ${2:Description}."
         ],
-		"description": "Add a services and utilities separator."
-    },
-
-    "Separator for watchers": {
-        "prefix": "separator-watchers",
-        "body": [
-            "",
-            "/////////////////////////////",
-            "//                         //",
-            "//        Watchers         //",
-            "//                         //",
-            "/////////////////////////////",
-            ""
-        ],
-		"description": "Add a watchers separator."
+		"description": "Add a '@return' tag."
     }
-
 }

--- a/snippets/typescript.json
+++ b/snippets/typescript.json
@@ -1,0 +1,231 @@
+{
+    // Misc
+
+	// ESLint/TSLint
+    "Disable ESLint": {
+        "prefix": "eslint-disable",
+        "body": [
+            "/* eslint-disable ${1:my-rule-name} */"
+        ],
+		"description": "Disable ESLint (with optional rule name to disable) from now on."
+    },
+    "Disable ESLint - Next line": {
+        "prefix": "eslint-disable-next",
+        "body": [
+            "// eslint-disable-next-line ${1:my-rule-name}"
+        ],
+		"description": "Disable ESLint (with optional rule name to disable) for the next line only."
+    },
+    "Enable ESLint": {
+        "prefix": "eslint-enable",
+        "body": [
+            "/* eslint-enable ${1:my-rule-name} */"
+        ],
+		"description": "(Re-)Enable ESLint (or rules) from now on."
+    },
+
+    "Disable TSLint": {
+        "prefix": "tslint-disable",
+        "body": [
+            "/* tslint-disable ${1:my-rule-name} */"
+        ],
+		"description": "Disable TSLint (with optional rule name to disable) from now on."
+    },
+    "Disable TSLint - Next line": {
+        "prefix": "tslint-disable-next",
+        "body": [
+            "// tslint-disable-next-line ${1:my-rule-name}"
+        ],
+		"description": "Disable TSLint (with optional rule name to disable) for the next line only."
+    },
+    "Enable TSLint": {
+        "prefix": "tslint-enable",
+        "body": [
+            "/* tslint-enable ${1:my-rule-name} */"
+        ],
+		"description": "(Re-)Enable TSLint (or rules) from now on."
+    },
+
+    // Separators
+    "Default separator": {
+        "prefix": "separator-default",
+        "body": [
+            "",
+            "/////////////////////////////",
+            ""
+        ],
+		"description": "Add a default separator."
+    },
+    "Separator for private attributes": {
+        "prefix": "separator-private-attributes",
+        "body": [
+            "",
+            "/////////////////////////////",
+            "//                         //",
+            "//    Private attributes   //",
+            "//                         //",
+            "/////////////////////////////",
+            ""
+        ],
+		"description": "Add a private attributes separator."
+    },
+    "Separator for public attributes": {
+        "prefix": "separator-public-attributes",
+        "body": [
+            "",
+            "/////////////////////////////",
+            "//                         //",
+            "//    Public attributes    //",
+            "//                         //",
+            "/////////////////////////////",
+            ""
+        ],
+		"description": "Add a public attributes separator."
+    },
+    "Separator for utilities": {
+        "prefix": "separator-utilities",
+        "body": [
+            "",
+            "/////////////////////////////",
+            "",
+            "/**",
+            " * Utilities.",
+            " */",
+            ""
+        ],
+		"description": "Add an utilities separator."
+    },
+    "Separator for private functions": {
+        "prefix": "separator-private-functions",
+        "body": [
+            "",
+            "/////////////////////////////",
+            "//                         //",
+            "//    Private functions    //",
+            "//                         //",
+            "/////////////////////////////",
+            ""
+        ],
+		"description": "Add a private functions separator."
+    },
+    "Separator for public functions": {
+        "prefix": "separator-public-functions",
+        "body": [
+            "",
+            "/////////////////////////////",
+            "//                         //",
+            "//     Public functions    //",
+            "//                         //",
+            "/////////////////////////////",
+            ""
+        ],
+		"description": "Add a public functions separator."
+    },
+
+    "EOF export": {
+        "prefix": "export",
+        "body": [
+            "",
+            "/////////////////////////////"
+            "",
+            "export { ${1:exportName} };"
+        ],
+		"description": "End of file export directive (with separator)."
+    },
+
+    // JSDoc
+    "JSDoc: '@type {string}'": {
+        "prefix": "@ts",
+        "body": [
+            "@type {string}"
+        ],
+		"description": "Add a '@type' tag for a string variable."
+    },
+    "JSDoc: '@type {Object}'": {
+        "prefix": "@to",
+        "body": [
+           "@type {Object}"
+        ],
+		"description": "Add a '@type' tag for an Object variable."
+    },
+    "JSDoc: '@type {number}'": {
+        "prefix": "@tn",
+        "body": [
+            "@type {number}"
+        ],
+		"description": "Add a '@type' tag for a number variable."
+    },
+    "JSDoc: '@type {Function}'": {
+        "prefix": "@tf",
+        "body": [
+            "@type {Function}"
+        ],
+		"description": "Add a '@type' tag for a Function variable."
+    },
+    "JSDoc: '@type {Date}'": {
+        "prefix": "@td",
+        "body": [
+            "@type {Date}"
+        ],
+		"description": "Add a '@type' tag for a Date variable."
+    },
+    "JSDoc: '@type {Array<?>}'": {
+        "prefix": "@ta",
+        "body": [
+            "@type {Array<${1:?>}"
+        ],
+		"description": "Add a '@type' tag for an Array variable."
+    },
+    "JSDoc: '@type {Date}'": {
+        "prefix": "@td",
+        "body": [
+            "@type {Date}"
+        ],
+		"description": "Add a '@type' tag for a Date variable."
+    },
+    "JSDoc: '@type'": {
+        "prefix": "@type",
+        "body": [
+            "@type {${1:*}}"
+        ],
+		"description": "Add a generic '@type' tag."
+    },
+
+    "JSDoc: '@constant'": {
+        "prefix": "@cst",
+        "body": [
+            "@constant"
+        ],
+		"description": "Add a '@constant' tag."
+    },
+    "JSDoc: '@readonly'": {
+        "prefix": "@ro",
+        "body": [
+            "@readonly"
+        ],
+		"description": "Add a '@readonly' tag."
+    },
+
+    "JSDoc: mandatory '@param'": {
+        "prefix": "@param",
+        "body": [
+            "@param {${1:*}} ${2:paramName} ${3:Description}."
+        ],
+		"description": "Add a mandatory '@param' tag."
+    },
+    "JSDoc: optional '@param'": {
+        "prefix": "@param-opt",
+        "body": [
+            "@param {${1:*}} [${2:paramName}=${3:<default value>}] ${4:Description}."
+        ],
+		"description": "Add an optional '@param' tag."
+    },
+
+    "JSDoc: '@return'": {
+        "prefix": "@return",
+        "body": [
+            "@return {${1:*}} ${2:Description}."
+        ],
+		"description": "Add a '@return' tag."
+    }
+}


### PR DESCRIPTION
Add TypeScript snippets:
- globally the same as the JavaScript ones, without the AngularJS part.

Add HTML snippets:
- these snippets are focused on the HTML documentation writing, particularly for the convention doc writing (with ESLint rules, blocks and code)

Add new JavaScript snippets:

- Fix the `ngInject` snippet (use directive instead of comment)
- Add new snippets for AngularJS (watcher, event listener, event sender, defined/undefined helper, forEach loop)
- Reorder the separators
- Add JSDoc snippets (types, param, return, constant, readonly, ...)
